### PR TITLE
Fix white space in labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,7 @@ function create_checkbox(id, label_name, group, map) {
     label.appendChild(document.createTextNode(label_name));
 
     group.appendChild(label);
+    group.appendChild(document.createTextNode(' '));
 
     document.getElementById(id_checkbox).addEventListener('change', function() {
         map[id] = this.checked;

--- a/index.html.in
+++ b/index.html.in
@@ -250,6 +250,7 @@ function create_checkbox(id, label_name, group, map) {
     label.appendChild(document.createTextNode(label_name));
 
     group.appendChild(label);
+    group.appendChild(document.createTextNode(' '));
 
     document.getElementById(id_checkbox).addEventListener('change', function() {
         map[id] = this.checked;


### PR DESCRIPTION
As noticed in #34, Firefox 77.0.1 was rendering the labels all in a single row, when the style `white-space: nowrap` is inside the label.

Adding a space between the labels apparently lets Firefox to break the lines as wished. In addition it shows the checkbox and its text more compact.

Tested in Chrome and Firefox in Ubuntu and Android.