### PR TITLE
UI: show red polygon on 'mouse over' the list

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,37 @@ var featureLayer = new ol.layer.Vector({
   style: style
 });
 
+var singleFeatureSource = new ol.source.Vector({});
+
+var styleSingleFeature = new ol.style.Style({
+    stroke : new ol.style.Stroke(
+    {
+        color : 'rgba(255, 0, 0, 1)',
+        width : 3
+    }),
+    fill : new ol.style.Fill(
+    {
+        color :  'rgba(255, 0, 0, 0.1)'
+    })
+});
+
+var singleFeatureLayer = new ol.layer.Vector({
+  source: singleFeatureSource,
+  style: styleSingleFeature
+});
+
+function updateSingleFeatureLayer(geometry) {
+    singleFeatureSource.clear();
+
+    if (geometry) {
+        var json = new ol.format.GeoJSON();
+        var feature = new ol.Feature({
+            geometry: json.readGeometry(geometry)
+        });
+        singleFeatureSource.addFeature(feature);
+    }
+}
+
 function agencies_selector(checked) {
     list_agencies.forEach(function(id){
         document.getElementById('id_checkbox_' + id).checked = checked;
@@ -303,7 +334,8 @@ closer.onclick = function() {
 var map = new ol.Map({
   layers: [
     new ol.layer.Tile({source: new ol.source.OSM()}),
-    featureLayer],
+    featureLayer,
+    singleFeatureLayer],
   renderer: 'canvas',
   target: 'map',
   overlays: [overlay],
@@ -335,7 +367,11 @@ map.on('singleclick', function(evt) {
         var props = feature.getProperties();
 
         details_innerHTML += '<hr>';
-        details_innerHTML += '<p><a href="' + props.name + '">' + props.name + '</a>: '
+        var writer = new ol.format.GeoJSON();
+        var geoJson = props.geometry ? writer.writeGeometry(props.geometry) : '';
+        details_innerHTML += '<p onmouseout="updateSingleFeatureLayer()" ';
+        details_innerHTML += " onmouseover='updateSingleFeatureLayer(" + geoJson + ")'>"; // geoJson contains double quotes
+        details_innerHTML += '<a href="' + props.name + '">' + props.name + '</a>: '
         if( props.area_of_use ) {
             details_innerHTML += props.area_of_use + ', ';
         }

--- a/index.html.in
+++ b/index.html.in
@@ -176,6 +176,37 @@ var featureLayer = new ol.layer.Vector({
   style: style
 });
 
+var singleFeatureSource = new ol.source.Vector({});
+
+var styleSingleFeature = new ol.style.Style({
+    stroke : new ol.style.Stroke(
+    {
+        color : 'rgba(255, 0, 0, 1)',
+        width : 3
+    }),
+    fill : new ol.style.Fill(
+    {
+        color :  'rgba(255, 0, 0, 0.1)'
+    })
+});
+
+var singleFeatureLayer = new ol.layer.Vector({
+  source: singleFeatureSource,
+  style: styleSingleFeature
+});
+
+function updateSingleFeatureLayer(geometry) {
+    singleFeatureSource.clear();
+
+    if (geometry) {
+        var json = new ol.format.GeoJSON();
+        var feature = new ol.Feature({
+            geometry: json.readGeometry(geometry)
+        });
+        singleFeatureSource.addFeature(feature);
+    }
+}
+
 function agencies_selector(checked) {
     list_agencies.forEach(function(id){
         document.getElementById('id_checkbox_' + id).checked = checked;
@@ -301,7 +332,8 @@ closer.onclick = function() {
 var map = new ol.Map({
   layers: [
     new ol.layer.Tile({source: new ol.source.OSM()}),
-    featureLayer],
+    featureLayer,
+    singleFeatureLayer],
   renderer: 'canvas',
   target: 'map',
   overlays: [overlay],
@@ -333,7 +365,11 @@ map.on('singleclick', function(evt) {
         var props = feature.getProperties();
 
         details_innerHTML += '<hr>';
-        details_innerHTML += '<p><a href="' + props.name + '">' + props.name + '</a>: '
+        var writer = new ol.format.GeoJSON();
+        var geoJson = props.geometry ? writer.writeGeometry(props.geometry) : '';
+        details_innerHTML += '<p onmouseout="updateSingleFeatureLayer()" ';
+        details_innerHTML += " onmouseover='updateSingleFeatureLayer(" + geoJson + ")'>"; // geoJson contains double quotes
+        details_innerHTML += '<a href="' + props.name + '">' + props.name + '</a>: '
         if( props.area_of_use ) {
             details_innerHTML += props.area_of_use + ', ';
         }


### PR DESCRIPTION
Sometimes there are many grid files in an area, and it is not clear in the list shown on the right hand side which one is each one.
This PR adds an event "onmouseover" (and "onmouseout") over the `<p>` sections on the list of grids displayed when the map is clicked, coloring it in red. Just moving the mouse over the list will show clearly each one.

See an example in the image. The mouse was over the text "... USA - Wisconsin ...".

![image](https://github.com/OSGeo/PROJ-data/assets/15678366/9975c1e0-fedd-42d6-b5a8-1fca5c967630)
