### PR TITLE
Introduce automatic release procedure via Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+#
+# GitHub Actions for automated PROJ-data release
+#
+# Only run on tags matching x.y.z or x.y.zRCn
+#
+# Automatically opens a draft release and uploads the packages build with CMake
+# as well as various checksum files. Manual steps includes adding release notes
+# and changes the release status from draft to final. Release candidates are
+# automatically set a pre-releases.
+
+name: 'Release'
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+RC[0-9]+'
+
+jobs:
+  release:
+    name: 'Release on Tag'
+    runs-on: ubuntu-latest
+
+    # Only run docbuild on central repo
+    if: github.repository == 'OSGeo/PROJ-data'
+    steps:
+
+    - name: 'Install'
+      run: |
+        pwd
+        uname -a
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends install cmake
+
+    - name: 'Check Out'
+      uses: actions/checkout@v4
+
+    - name: 'Final release?'
+      id: release_type
+      run: |
+        echo "final_release=false" >> $GITHUB_OUTPUT
+        echo tag=${{github.ref_name}}
+        if [[ ${{ github.ref_name }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "final_release=true" >> $GITHUB_OUTPUT
+        fi
+        cat $GITHUB_OUTPUT
+
+
+    - name: 'Bundle & Check Package'
+      id: bundle
+      run: |
+        pwd
+        set -e
+        
+        mkdir _build && cd _build
+        cmake --version
+        cmake ..
+        cmake --build . --target dist
+        
+        extensions=".tar.gz .zip"
+        for ext in $extensions
+        do
+            for filename in $(ls *$ext)
+            do
+                `md5sum $filename > $filename.md5`
+                `sha256sum $filename > $filename.sha256sum`
+                `sha512sum $filename > $filename.sha512sum`
+            done
+        done
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: false
+        draft: true
+        name: PROJ-data ${{ github.ref_name }}
+        prerelease: ${{ steps.release_type.outputs.final_release == 'false' }}
+        files: |
+          ./_build/proj-data-*

--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -17,7 +17,7 @@ Preparing a PROJ-data Release
    
 5. Publish release on GitHub
 
-6. Upload package files to download.osgeo.org
+6. Upload the generated `proj-data-*`- files to download.osgeo.org
 
 7. Resynchronize CDN content from repository with ./sync_to_cdn.sh
 

--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -1,21 +1,24 @@
 Preparing a PROJ-data Release
 ===============================================================================
 
-0. Have cmake installed
-
 1. If index.html is not already up-to-date with latest grid additions,
     a. Have GDAL (>= 2.4) Python3 bindings installed
     b. python3 regenerate_index_html.py
     c. git commit -a -m "Update index.html" && git push
 
 2. Edit CMakeLists.txt to update PROJ_DATA_VERSION_MAJOR and PROJ_DATA_VERSION_MINOR
+    a. Add RCn to PROJ_DATA_VERSION_MINOR if this is a release candidate
 
 3. git commit -a -m "Update CMakeLists.txt to vX.Y" && git push
 
-4. mkdir build && cd build && cmake .. && make dist
+4. Tag commit with version number (including release candidate number when relevant).
+   Push tag to GitHub where the packages for distribution will be automatically generated
+   and a draft release will be prepared.
+   
+5. Publish release on GitHub
 
-   ==> proj-data-X.Y.zip and proj-data-X.Y.tar.gz
+6. Upload package files to download.osgeo.org
 
-5. Resynchronize CDN content from repository with ./sync_to_cdn.sh
+7. Resynchronize CDN content from repository with ./sync_to_cdn.sh
 
-6. Close the previous milestone and open a new one
+8. Close the previous milestone and open a new one


### PR DESCRIPTION
This enables automatic creation of the distribution packages for PROJ-data. When a tag is pushed the release procedure is started, which creates a new draft release here on GitHub where the packages as well as some checksum files are attached. The files can then manually be uploaded to the OSGeo servers for the actual release (might be possible to automate this as well in the future). If a tag on the form `x.y.zRCn` is pushed a draft for a pre-release is created.

For now I've just added some brief notes to `HOWTORELEASE.md`. I might revise them after the first proper release using this setup.

An example of a automatically prepared release can be seen at my fork of the repo: https://github.com/kbevers/PROJ-data/releases/tag/1.19.6 

Closes #122 