### PR TITLE
CMakeLists.txt: bump minimum CMake version to 3.16 to avoid warnings …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build system for proj-data releases.
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.16)
 
 project(PROJ_DATA)
 set(PROJ_DATA_VERSION_MAJOR 1)


### PR DESCRIPTION
…about support for older versions being deprecated